### PR TITLE
improve column width calculation algorithm

### DIFF
--- a/table/table_test.go
+++ b/table/table_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/martinohmann/neat/bar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -41,6 +42,10 @@ func (s *Suite) testTableRender(table *Table, expected string) {
 
 func (s *Suite) TestTable_Render() {
 	s.testTableRender(
+		New(40),
+		``,
+	)
+	s.testTableRender(
 		New(40).
 			AddRow("foo\nbarbaz", "qux"),
 		`
@@ -56,10 +61,17 @@ foo.bar
 `,
 	)
 	s.testTableRender(
+		New(13).
+			AddRow("foo", "barbaz", "qux"),
+		`
+foo.barb….qux
+`,
+	)
+	s.testTableRender(
 		New(10).
 			AddRow("foo", "bar", "baz"),
 		`
-f….b….b…
+f….bar.baz
 `,
 	)
 	s.testTableRender(
@@ -71,6 +83,47 @@ f….b….b…
 foo....bar....baz...
 foofoo.barbar.bazbaz
 1......2......foo...
+`,
+	)
+	s.testTableRender(
+		New(40).
+			AddRow(
+				"foo",
+				bar.Bar{
+					MaxWidth:       -1,
+					Completed:      10,
+					RemainingStyle: bar.NewStyle('-', nil),
+					CompletedStyle: bar.NewStyle('#', nil),
+					FinishedStyle:  bar.NewStyle('#', nil),
+				},
+				"qux",
+			),
+		`
+foo.###-----------------------------.qux
+`,
+	)
+	s.testTableRender(
+		New(18).
+			AddRow(
+				"foo",
+				bar.Bar{
+					MaxWidth:       -1,
+					Completed:      10,
+					RemainingStyle: bar.NewStyle('-', nil),
+					CompletedStyle: bar.NewStyle('#', nil),
+					FinishedStyle:  bar.NewStyle('#', nil),
+				},
+				bar.Bar{
+					MaxWidth:       -1,
+					Completed:      40,
+					RemainingStyle: bar.NewStyle('-', nil),
+					CompletedStyle: bar.NewStyle('#', nil),
+					FinishedStyle:  bar.NewStyle('#', nil),
+				},
+				"qux",
+			),
+		`
+foo.----.##---.qux
 `,
 	)
 }


### PR DESCRIPTION
This replaces the naive column width calculation with something better.
It first tries to fit all columns using their maximum requested width.
If this is not possible it will try to give each column its fair space
share which may be less than the requested maximum, but will be at least
the requested minimum width. As a last resort it will try to allocate
the requested minimum width where possible, truncating columns where not
even this is possible.