### PR TITLE
infer table max table width from writer

### DIFF
--- a/_examples/table/main.go
+++ b/_examples/table/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/martinohmann/neat/console"
 	"github.com/martinohmann/neat/style"
 	"github.com/martinohmann/neat/table"
 	"github.com/martinohmann/neat/text"
@@ -12,13 +12,12 @@ import (
 const lorem = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
 
 func main() {
-	maxWidth := console.TerminalWidth(os.Stdout)
-
-	t := table.New(
-		maxWidth,
+	opts := []table.Option{
 		table.WithPadding(4),
 		table.WithAlignment(text.AlignLeft, text.AlignJustify, text.AlignRight),
-	)
+	}
+
+	t := table.New(os.Stdout, opts...)
 
 	bold := style.New(style.Bold)
 
@@ -42,5 +41,22 @@ func main() {
 	t.AddRow(bold.Sprint("left aligned"), bold.Sprint("justify + wordwrap"), bold.Sprint("right aligned"))
 	t.AddRow(left, center, right)
 
-	t.Render(os.Stdout)
+	n, err := t.Render()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("\n%d lines rendered\n\n", n)
+
+	t = table.New(os.Stdout)
+
+	t.AddRow(1, 2, 3)
+	t.AddRow("one", "two", "three")
+
+	n, err = t.Render()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("\n%d lines rendered\n", n)
 }

--- a/measure/measurement.go
+++ b/measure/measurement.go
@@ -36,3 +36,14 @@ func (m Measurement) Span() int {
 	m = m.Normalize()
 	return m.Maximum - m.Minimum
 }
+
+// Sum sums up the min and max values of all passed in measurements and returns
+// a new Measurement.
+func Sum(measures ...Measurement) (sum Measurement) {
+	for _, measure := range measures {
+		sum.Minimum += measure.Minimum
+		sum.Maximum += measure.Maximum
+	}
+
+	return sum
+}

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -150,9 +150,7 @@ func (p *Progress) update(cursor *terminal.Cursor) bool {
 		cursor.Up(p.displayHeight)
 	}
 
-	termWidth := console.TerminalWidth(p.out)
-
-	table := table.New(termWidth, p.tableOptions...)
+	table := table.New(p.out, p.tableOptions...)
 
 	for _, task := range p.tasks {
 		if !task.Started() {
@@ -162,7 +160,7 @@ func (p *Progress) update(cursor *terminal.Cursor) bool {
 		table.AddRow(p.tableColumns(task)...)
 	}
 
-	tableHeight, err := table.Render(p.out)
+	tableHeight, err := table.Render()
 	if err != nil {
 		panic(fmt.Errorf("failed to render task progress: %v", err))
 	}

--- a/table/options.go
+++ b/table/options.go
@@ -20,6 +20,15 @@ func WithMargin(margin int) Option {
 	}
 }
 
+// WithMaxWidth sets the maximum table width. If maxWidth is <= 0, maxWidth is
+// inferred from the table's underlying io.Writer if it is a
+// console.FileWriter, otherwise a default of 80 is used.
+func WithMaxWidth(maxWidth int) Option {
+	return func(t *Table) {
+		t.maxWidth = maxWidth
+	}
+}
+
 func WithAlignment(alignments ...text.Alignment) Option {
 	return func(t *Table) {
 		t.alignments = alignments


### PR DESCRIPTION
If the underlying io.Writer for the table is a console.FileWriter use
the terminal width if maxWidth is not explicitly set or fall back to a
default of 80. This makes the interface a little bit nicer.