### PR TITLE
add support for table borders

### DIFF
--- a/_examples/table/main.go
+++ b/_examples/table/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/martinohmann/neat/console"
 	"github.com/martinohmann/neat/style"
 	"github.com/martinohmann/neat/table"
 	"github.com/martinohmann/neat/text"
@@ -12,9 +12,14 @@ import (
 const lorem = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
 
 func main() {
+	console.Printf("1. {bold}lorem ipsum with colored borders and margin\n\n")
+
 	opts := []table.Option{
-		table.WithPadding(4),
+		table.WithPadding(1),
+		table.WithMargin(2),
 		table.WithAlignment(text.AlignLeft, text.AlignJustify, text.AlignRight),
+		table.WithBorderMask(table.BorderAll),
+		table.WithBorderStyle(style.New(style.Bold, style.FgBlack)),
 	}
 
 	t := table.New(os.Stdout, opts...)
@@ -40,23 +45,33 @@ func main() {
 
 	t.AddRow(bold.Sprint("left aligned"), bold.Sprint("justify + wordwrap"), bold.Sprint("right aligned"))
 	t.AddRow(left, center, right)
+	t.AddRow(left.Text[:100], center, right)
 
-	n, err := t.Render()
-	if err != nil {
-		panic(err)
-	}
+	t.Render()
 
-	fmt.Printf("\n%d lines rendered\n\n", n)
+	console.Printf("\n{bold}2. table with only column and bottom borders and custom border rune\n\n")
 
-	t = table.New(os.Stdout)
+	t = table.New(
+		os.Stdout,
+		table.WithBorderMask(table.BorderColumn|table.BorderBottom),
+		table.WithBorderStyle(style.New(style.FgRGB(200, 100, 0))),
+		table.WithBorderRunes(table.BorderRunes{
+			table.BorderRuneVertical:           '║',
+			table.BorderRuneIntersectionBottom: '╨',
+		}),
+	)
 
 	t.AddRow(1, 2, 3)
 	t.AddRow("one", "two", "three")
 
-	n, err = t.Render()
-	if err != nil {
-		panic(err)
-	}
+	t.Render()
 
-	fmt.Printf("\n%d lines rendered\n", n)
+	console.Printf("\n{bold}3. simple table, no borders\n\n")
+
+	t = table.New(os.Stdout)
+
+	t.AddRow("FOO", "BAR", "BAZ")
+	t.AddRow("ten", "eleven", "twelve")
+
+	t.Render()
 }

--- a/table/border.go
+++ b/table/border.go
@@ -1,0 +1,66 @@
+package table
+
+// BorderMask controls which borders should be displayed.
+type BorderMask int
+
+// Has returns true if b has the bits of mask set.
+func (b BorderMask) Has(mask BorderMask) bool {
+	return b&mask == mask
+}
+
+// BorderMask options.
+const (
+	BorderNone BorderMask = 1 << iota
+	BorderLeft
+	BorderColumn
+	BorderRight
+	BorderTop
+	BorderRow
+	BorderBottom
+
+	BorderAllHorizontal = BorderTop | BorderRow | BorderBottom
+	BorderAllVertical   = BorderLeft | BorderColumn | BorderRight
+	BorderAll           = BorderAllHorizontal | BorderAllVertical
+)
+
+// BorderRune indicates the type of rune used for a border.
+type BorderRune int
+
+// BorderRune elements that are needed to draw a table with corners,
+// intersections, row separators (horizontal) and column separators (vertical
+// borders). Can be configured on a table via the WithBorderRunes table option.
+// See DefaultBorderRunes for a mapping of these constants to actual runes.
+const (
+	BorderRuneHorizontal         BorderRune = iota // ─
+	BorderRuneVertical                             // │
+	BorderRuneCornerTopLeft                        // ┌
+	BorderRuneCornerTopRight                       // ┐
+	BorderRuneCornerBottomLeft                     // └
+	BorderRuneCornerBottomRight                    // └
+	BorderRuneIntersectionTop                      // ┬
+	BorderRuneIntersectionBottom                   // ┴
+	BorderRuneIntersectionLeft                     // ├
+	BorderRuneIntersectionRight                    // ┤
+	BorderRuneIntersectionCenter                   // ┼
+)
+
+// BorderRunes is a map of the BorderRune type to the actual rune that should
+// be displayed.
+type BorderRunes map[BorderRune]rune
+
+// DefaultBorderRunes are the runes that will be used to draw table borders if
+// not explicitly overridden via table options. This is an exported variable to
+// allow overriding table borders globally.
+var DefaultBorderRunes = BorderRunes{
+	BorderRuneHorizontal:         '─',
+	BorderRuneVertical:           '│',
+	BorderRuneCornerTopLeft:      '┌',
+	BorderRuneCornerTopRight:     '┐',
+	BorderRuneCornerBottomLeft:   '└',
+	BorderRuneCornerBottomRight:  '┘',
+	BorderRuneIntersectionTop:    '┬',
+	BorderRuneIntersectionBottom: '┴',
+	BorderRuneIntersectionLeft:   '├',
+	BorderRuneIntersectionRight:  '┤',
+	BorderRuneIntersectionCenter: '┼',
+}

--- a/table/options.go
+++ b/table/options.go
@@ -1,6 +1,9 @@
 package table
 
-import "github.com/martinohmann/neat/text"
+import (
+	"github.com/martinohmann/neat/style"
+	"github.com/martinohmann/neat/text"
+)
 
 // Option is a func for configuring a *Table.
 type Option func(t *Table)
@@ -13,7 +16,7 @@ func WithPadding(padding int) Option {
 	}
 }
 
-// WidthMargin sets the left and right margin of table rows. Defaults to 0.
+// WithMargin sets the left and right margin of table rows. Defaults to 0.
 func WithMargin(margin int) Option {
 	return func(t *Table) {
 		t.margin = margin
@@ -26,6 +29,33 @@ func WithMargin(margin int) Option {
 func WithMaxWidth(maxWidth int) Option {
 	return func(t *Table) {
 		t.maxWidth = maxWidth
+	}
+}
+
+// WithBorderMask controls the borders that should be displayed using a bit
+// mask.
+func WithBorderMask(mask BorderMask) Option {
+	return func(t *Table) {
+		t.borderMask = mask
+	}
+}
+
+// WithBorderRunes sets the runes that should be rendered for the individual
+// border elements, e.g. corners, vertical and horizontal lines and junctions.
+// See the documentation of DefaultBorderRunes for an example. It is valid to
+// pass a rune mapping for a subset of the required border runes. Missing runes
+// will be filled with the corresponding runes from DefaultBorderRunes.
+func WithBorderRunes(runes BorderRunes) Option {
+	return func(t *Table) {
+		t.borderRunes = runes
+	}
+}
+
+// WithBorderStyle sets the style the should be applied to each border element.
+// The default is to not apply any style.
+func WithBorderStyle(style *style.Style) Option {
+	return func(t *Table) {
+		t.borderStyle = style
 	}
 }
 

--- a/table/table_builder.go
+++ b/table/table_builder.go
@@ -1,0 +1,132 @@
+package table
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/martinohmann/neat/measure"
+	"github.com/martinohmann/neat/text"
+)
+
+// tableBuilder builds the string representation of a table and writes it to
+// the underlying io.Writer of the wrapped *Table.
+type tableBuilder struct {
+	strings.Builder
+	*Table
+
+	measures      []measure.Measurement
+	marginSpaces  string
+	paddingSpaces string
+	lines         int
+}
+
+func newTableBuilder(t *Table, measures []measure.Measurement) *tableBuilder {
+	return &tableBuilder{
+		Table:         t,
+		measures:      measures,
+		marginSpaces:  text.Spaces(t.margin),
+		paddingSpaces: text.Spaces(t.padding),
+	}
+}
+
+func (tb *tableBuilder) writeBorderString(s string) {
+	if tb.borderStyle != nil {
+		s = tb.borderStyle.Sprint(s)
+	}
+
+	tb.WriteString(s)
+}
+
+func (tb *tableBuilder) writeBorderRuneN(r BorderRune, n int) {
+	tb.writeBorderString(strings.Repeat(string(tb.borderRunes[r]), n))
+}
+
+func (tb *tableBuilder) writeBorderRune(r BorderRune) {
+	tb.writeBorderString(string(tb.borderRunes[r]))
+}
+
+func (tb *tableBuilder) writePaddingSpaces() { tb.WriteString(tb.paddingSpaces) }
+
+func (tb *tableBuilder) writeMarginSpaces() { tb.WriteString(tb.marginSpaces) }
+
+func (tb *tableBuilder) writeNewline() {
+	tb.WriteRune('\n')
+	tb.lines++
+}
+
+func (tb *tableBuilder) writeRowCells(cellLines [][]string, maxCellHeight int) {
+	// Write all cells of the current row to the buffer and handle multiple
+	// lines.
+	for lineNum := 0; lineNum < maxCellHeight; lineNum++ {
+		tb.writeMarginSpaces()
+
+		if tb.borderMask.Has(BorderLeft) {
+			tb.writeBorderRune(BorderRuneVertical)
+			tb.writePaddingSpaces()
+		}
+
+		for colIdx, lines := range cellLines {
+			if lineNum < len(lines) {
+				tb.WriteString(lines[lineNum])
+			} else {
+				tb.WriteString(text.Spaces(tb.measures[colIdx].Maximum))
+			}
+
+			// Insert padding after each column except the last one.
+			if colIdx < len(cellLines)-1 {
+				tb.writePaddingSpaces()
+
+				if tb.borderMask.Has(BorderColumn) {
+					tb.writeBorderRune(BorderRuneVertical)
+					tb.writePaddingSpaces()
+				}
+			}
+		}
+
+		if tb.borderMask.Has(BorderRight) {
+			tb.writePaddingSpaces()
+			tb.writeBorderRune(BorderRuneVertical)
+		}
+
+		tb.writeMarginSpaces()
+		tb.writeNewline()
+	}
+}
+
+func (tb *tableBuilder) writeBorderLine(left, junction, right BorderRune) {
+	tb.writeMarginSpaces()
+
+	if tb.borderMask.Has(BorderLeft) {
+		tb.writeBorderRune(left)
+		tb.writeBorderRuneN(BorderRuneHorizontal, tb.padding)
+	}
+
+	for i, measure := range tb.measures {
+		line := strings.Repeat(string(tb.borderRunes[BorderRuneHorizontal]), measure.Maximum)
+
+		tb.writeBorderString(line)
+
+		if i < len(tb.measures)-1 {
+			tb.writeBorderRuneN(BorderRuneHorizontal, tb.padding)
+
+			if tb.borderMask.Has(BorderColumn) {
+				tb.writeBorderRune(junction)
+				tb.writeBorderRuneN(BorderRuneHorizontal, tb.padding)
+			}
+		}
+	}
+
+	if tb.borderMask.Has(BorderRight) {
+		tb.writeBorderRuneN(BorderRuneHorizontal, tb.padding)
+		tb.writeBorderRune(right)
+	}
+
+	tb.writeMarginSpaces()
+	tb.writeNewline()
+}
+
+func (tb *tableBuilder) render() (int, error) {
+	_, err := fmt.Fprint(tb.out, tb.String())
+
+	return tb.lines, err
+}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/martinohmann/neat/bar"
+	"github.com/martinohmann/neat/style"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -64,6 +65,8 @@ func (s *Suite) testTableRender(factory func(w io.Writer) *Table, expected strin
 }
 
 func (s *Suite) TestTable_Render() {
+	defer style.Enable()()
+
 	s.testTableRender(
 		func(w io.Writer) *Table {
 			return New(w)
@@ -174,6 +177,90 @@ foo.###-----------------------------.qux
 		`
 foo.----.##---.qux
 `,
+	)
+	s.testTableRender(
+		func(w io.Writer) *Table {
+			return New(w, WithBorderMask(BorderAll)).
+				AddRow("foo", "bar", "baz").
+				AddRow("foofoo", "barbar", "bazbaz").
+				AddRow(1, 2, "foo")
+		},
+		`
+┌────────┬────────┬────────┐
+│ foo    │ bar    │ baz    │
+├────────┼────────┼────────┤
+│ foofoo │ barbar │ bazbaz │
+├────────┼────────┼────────┤
+│ 1      │ 2      │ foo    │
+└────────┴────────┴────────┘
+`,
+	)
+	s.testTableRender(
+		func(w io.Writer) *Table {
+			return New(w, WithBorderMask(BorderRow)).
+				AddRow("foo", "bar", "baz").
+				AddRow("foofoo", "barbar", "bazbaz").
+				AddRow(1, 2, "foo")
+		},
+		`
+foo    bar    baz   
+────────────────────
+foofoo barbar bazbaz
+────────────────────
+1      2      foo   
+`,
+	)
+	s.testTableRender(
+		func(w io.Writer) *Table {
+			return New(w, WithBorderMask(BorderRow|BorderColumn)).
+				AddRow("foo", "bar", "baz").
+				AddRow("foofoo", "barbar", "bazbaz").
+				AddRow(1, 2, "foo")
+		},
+		`
+foo    │ bar    │ baz   
+───────┼────────┼───────
+foofoo │ barbar │ bazbaz
+───────┼────────┼───────
+1      │ 2      │ foo   
+`,
+	)
+	s.testTableRender(
+		func(w io.Writer) *Table {
+			return New(w, WithBorderMask(BorderAllVertical)).
+				AddRow("foo", "bar", "baz").
+				AddRow("foofoo", "barbar", "bazbaz").
+				AddRow(1, 2, "foo")
+		},
+		`
+│ foo    │ bar    │ baz    │
+│ foofoo │ barbar │ bazbaz │
+│ 1      │ 2      │ foo    │
+`,
+	)
+	s.testTableRender(
+		func(w io.Writer) *Table {
+			return New(w, WithBorderMask(BorderAll^BorderRow)).
+				AddRow("foo", "bar", "baz").
+				AddRow("foofoo", "barbar", "bazbaz").
+				AddRow(1, 2, "foo")
+		},
+		`
+┌────────┬────────┬────────┐
+│ foo    │ bar    │ baz    │
+│ foofoo │ barbar │ bazbaz │
+│ 1      │ 2      │ foo    │
+└────────┴────────┴────────┘
+`,
+	)
+	s.testTableRender(
+		func(w io.Writer) *Table {
+			return New(w, WithBorderMask(BorderAll), WithBorderStyle(style.New(style.FgBlack))).
+				AddRow("foo", "bar")
+		},
+		"\x1b[30m┌\x1b[0m\x1b[30m─\x1b[0m\x1b[30m───\x1b[0m\x1b[30m─\x1b[0m\x1b[30m┬\x1b[0m\x1b[30m─\x1b[0m\x1b[30m───\x1b[0m\x1b[30m─\x1b[0m\x1b[30m┐\x1b[0m\n"+
+			"\x1b[30m│\x1b[0m foo \x1b[30m│\x1b[0m bar \x1b[30m│\x1b[0m\n"+
+			"\x1b[30m└\x1b[0m\x1b[30m─\x1b[0m\x1b[30m───\x1b[0m\x1b[30m─\x1b[0m\x1b[30m┴\x1b[0m\x1b[30m─\x1b[0m\x1b[30m───\x1b[0m\x1b[30m─\x1b[0m\x1b[30m┘\x1b[0m\n",
 	)
 }
 


### PR DESCRIPTION
table.New now accepts the table.WithBorderMask, table.WithBorderRunes and table.WithBorderStyle options to draw borders around a table.